### PR TITLE
[SPEC] Add urAdapterSetLoggingCallback entrypoint

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1005,6 +1005,11 @@ typedef void (*ur_logger_callback_t)(
 ///       implement this feature for any entrypoint.
 ///     - The application can disable log messages at runtime by setting the
 ///       environment variable `UR_DISABLE_LOGS`.
+///     - Calling this function again with the same adapter handle will replace
+///       the previous values.
+///     - To unset the callback, use `nullptr` as the value for `pfnLogger`.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be thread-safe.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1013,14 +1018,19 @@ typedef void (*ur_logger_callback_t)(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phAdapters`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOG_LEVEL_ERR < levelThreshold`
 UR_APIEXPORT ur_result_t UR_APICALL
 urAdapterSetLoggingCallback(
     ur_adapter_handle_t *phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                                      ///< be set.
     uint32_t NumAdapters,            ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t levelThreshold,   ///< [in] The minimum log level that will activate pfnLogger.
+                                     ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+                                     ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t pfnLogger,  ///< [in][optional] Function pointer to the callback function that will
                                      ///< process the warning messages.
-                                     ///< If set to nullptr, the callback function will be unset."
+                                     ///< If set to nullptr, the callback function will be unset.
     void *pUserData                  ///< [in][out][optional] pointer to data to be passed to the callback.
 );
 
@@ -10080,6 +10090,7 @@ typedef struct ur_adapter_get_info_params_t {
 typedef struct ur_adapter_set_logging_callback_params_t {
     ur_adapter_handle_t **pphAdapters;
     uint32_t *pNumAdapters;
+    ur_log_level_t *plevelThreshold;
     ur_logger_callback_t *ppfnLogger;
     void **ppUserData;
 } ur_adapter_set_logging_callback_params_t;

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -489,8 +489,8 @@ typedef enum ur_result_t {
     UR_RESULT_ERROR_INVALID_HOST_PTR = 64,                                    ///< Invalid host pointer
     UR_RESULT_ERROR_INVALID_USM_SIZE = 65,                                    ///< Invalid USM size
     UR_RESULT_ERROR_OBJECT_ALLOCATION_FAILURE = 66,                           ///< Objection allocation failure
-    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 67,                                    ///< An adapter specific warning/error has been reported and can be
-                                                                              ///< retrieved via the urPlatformGetLastError entry point.
+    UR_RESULT_ERROR_ADAPTER_SPECIFIC = 67,                                    ///< An adapter specific error has been reported and can be retrieved via
+                                                                              ///< the urAdapterGetLastError entry point.
     UR_RESULT_ERROR_LAYER_NOT_PRESENT = 68,                                   ///< A requested layer was not found by the loader.
     UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 0x1000,                      ///< Invalid Command-Buffer
     UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 0x1001,           ///< Sync point is not valid for the command-buffer
@@ -890,7 +890,7 @@ urAdapterRetain(
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///
-/// * The message and error code storage is will only be valid if a previously
+/// * The message and error code storage will only be valid if a previously
 ///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///
 /// * The memory pointed to by the C string returned in `ppMessage` is owned by
@@ -921,6 +921,8 @@ urAdapterRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
 ///         + `NULL == pError`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
@@ -1003,8 +1005,6 @@ typedef void (*ur_logger_callback_t)(
 ///       specified in `phAdapters`.
 ///     - Sending log messages is optional and adapters are not required to
 ///       implement this feature for any entrypoint.
-///     - The application can disable log messages at runtime by setting the
-///       environment variable `UR_DISABLE_LOGS`.
 ///     - Calling this function again with the same adapter handle will replace
 ///       the previous values.
 ///     - To unset the callback, use `nullptr` as the value for `pfnLogger`.

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1016,6 +1016,14 @@ typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetInfo_t)(
     size_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterSetLoggingCallback
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggingCallback_t)(
+    ur_adapter_handle_t *,
+    uint32_t,
+    ur_logger_callback_t,
+    void *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Global functions pointers
 typedef struct ur_global_dditable_t {
     ur_pfnAdapterGet_t pfnAdapterGet;
@@ -1023,6 +1031,7 @@ typedef struct ur_global_dditable_t {
     ur_pfnAdapterRetain_t pfnAdapterRetain;
     ur_pfnAdapterGetLastError_t pfnAdapterGetLastError;
     ur_pfnAdapterGetInfo_t pfnAdapterGetInfo;
+    ur_pfnAdapterSetLoggingCallback_t pfnAdapterSetLoggingCallback;
 } ur_global_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1020,6 +1020,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnAdapterGetInfo_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggingCallback_t)(
     ur_adapter_handle_t *,
     uint32_t,
+    ur_log_level_t,
     ur_logger_callback_t,
     void *);
 

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -43,6 +43,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintStructureType(enum ur_structure_type_
 UR_APIEXPORT ur_result_t UR_APICALL urPrintResult(enum ur_result_t value, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_log_level_t enum
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintLogLevel(enum ur_log_level_t value, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_base_properties_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1729,6 +1737,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetLastErrorParams(const struc
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterGetInfoParams(const struct ur_adapter_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_set_logging_callback_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterSetLoggingCallbackParams(const struct ur_adapter_set_logging_callback_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_enqueue_kernel_launch_params_t struct

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -12298,6 +12298,11 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << *(params->pNumAdapters);
 
     os << ", ";
+    os << ".levelThreshold = ";
+
+    os << *(params->plevelThreshold);
+
+    os << ", ";
     os << ".pfnLogger = ";
 
     os << reinterpret_cast<void *>(

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -215,6 +215,7 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_exp_peer_in
 inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_structure_type_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_log_level_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_base_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_base_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_rect_offset_t params);
@@ -912,6 +913,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_DEVICE_GET_SELECTED:
         os << "UR_FUNCTION_DEVICE_GET_SELECTED";
         break;
+    case UR_FUNCTION_ADAPTER_SET_LOGGING_CALLBACK:
+        os << "UR_FUNCTION_ADAPTER_SET_LOGGING_CALLBACK";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -1550,6 +1554,30 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
         break;
     case UR_RESULT_ERROR_UNKNOWN:
         os << "UR_RESULT_ERROR_UNKNOWN";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_log_level_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, enum ur_log_level_t value) {
+    switch (value) {
+    case UR_LOG_LEVEL_DEBUG:
+        os << "UR_LOG_LEVEL_DEBUG";
+        break;
+    case UR_LOG_LEVEL_INFO:
+        os << "UR_LOG_LEVEL_INFO";
+        break;
+    case UR_LOG_LEVEL_WARN:
+        os << "UR_LOG_LEVEL_WARN";
+        break;
+    case UR_LOG_LEVEL_ERR:
+        os << "UR_LOG_LEVEL_ERR";
         break;
     default:
         os << "unknown enumerator";
@@ -12248,6 +12276,43 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_set_logging_callback_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_adapter_set_logging_callback_params_t *params) {
+
+    os << ".phAdapters = {";
+    for (size_t i = 0; *(params->pphAdapters) != NULL && i < *params->pNumAdapters; ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur::details::printPtr(os,
+                              (*(params->pphAdapters))[i]);
+    }
+    os << "}";
+
+    os << ", ";
+    os << ".NumAdapters = ";
+
+    os << *(params->pNumAdapters);
+
+    os << ", ";
+    os << ".pfnLogger = ";
+
+    os << reinterpret_cast<void *>(
+        *(params->ppfnLogger));
+
+    os << ", ";
+    os << ".pUserData = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppUserData));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_enqueue_kernel_launch_params_t type
 /// @returns
 ///     std::ostream &
@@ -16864,6 +16929,9 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     } break;
     case UR_FUNCTION_ADAPTER_GET_INFO: {
         os << (const struct ur_adapter_get_info_params_t *)params;
+    } break;
+    case UR_FUNCTION_ADAPTER_SET_LOGGING_CALLBACK: {
+        os << (const struct ur_adapter_set_logging_callback_params_t *)params;
     } break;
     case UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH: {
         os << (const struct ur_enqueue_kernel_launch_params_t *)params;

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -83,7 +83,7 @@ details: |
     * Implementations *must* store the message and error code in thread-local
       storage prior to returning $X_RESULT_ERROR_ADAPTER_SPECIFIC.
 
-    * The message and error code storage is will only be valid if a previously
+    * The message and error code storage will only be valid if a previously
       called entry-point returned $X_RESULT_ERROR_ADAPTER_SPECIFIC.
 
     * The memory pointed to by the C string returned in `ppMessage` is owned by
@@ -121,6 +121,9 @@ params:
       desc: >
           [out] pointer to an integer where the adapter specific error code
           will be stored.
+returns:
+  - $X_RESULT_ERROR_OUT_OF_RESOURCES
+  - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Supported adapter info"
@@ -201,7 +204,6 @@ details:
   - "Sets a function callback that will be used by the adapters when logging messages."
   - "The callback will be called for every message logged by the adapters specified in `phAdapters`."
   - "Sending log messages is optional and adapters are not required to implement this feature for any entrypoint."
-  - "The application can disable log messages at runtime by setting the environment variable `UR_DISABLE_LOGS`."
   - "Calling this function again with the same adapter handle will replace the previous values."
   - "To unset the callback, use `nullptr` as the value for `pfnLogger`."
   - "The application may call this function from simultaneous threads."

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -202,6 +202,10 @@ details:
   - "The callback will be called for every message logged by the adapters specified in `phAdapters`."
   - "Sending log messages is optional and adapters are not required to implement this feature for any entrypoint."
   - "The application can disable log messages at runtime by setting the environment variable `UR_DISABLE_LOGS`."
+  - "Calling this function again with the same adapter handle will replace the previous values."
+  - "To unset the callback, use `nullptr` as the value for `pfnLogger`."
+  - "The application may call this function from simultaneous threads."
+  - "The implementation of this function should be thread-safe."
 class: $x
 name: AdapterSetLoggingCallback
 decl: static
@@ -212,11 +216,16 @@ params:
   - type: "uint32_t"
     name: NumAdapters
     desc: "[in] number of adapters pointed to by phAdapters."
+  - type: $x_log_level_t
+    name: levelThreshold
+    desc: |
+          [in] The minimum log level that will activate pfnLogger.
+          For example, if logLevel is $X_LOG_LEVEL_INFO, all messages except for $X_LOG_LEVEL_DEBUG will trigger a call to the callback.
   - type: $x_logger_callback_t
     name: pfnLogger
     desc: |
           [in][optional] Function pointer to the callback function that will process the warning messages.
-          If set to nullptr, the callback function will be unset."
+          If set to nullptr, the callback function will be unset.
   - type: void*
     name: pUserData
     desc: "[in][out][optional] pointer to data to be passed to the callback."

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -177,6 +177,50 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
 --- #--------------------------------------------------------------------------
+type: fptr_typedef
+desc: "Callback function that processes adapter log messages."
+name: $x_logger_callback_t
+return: void
+params:
+  - type: $x_adapter_handle_t
+    name: hAdapter
+    desc: "[in] handle of the adapter"
+  - type: const char*
+    name: message
+    desc: "[in] the log message set by the unified runtime adapter."
+  - type: $x_log_level_t
+    name: logLevel
+    desc: "[in] The log message type"
+  - type: void*
+    name: pUserData
+    desc: "[in][optional] pointer to user data to be passed to the callback."
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Set a function callback for use by the adapters when logging messages."
+details:
+  - "Sets a function callback that will be used by the adapters when logging messages."
+  - "The callback will be called for every message logged by the adapters specified in `phAdapters`."
+  - "Sending log messages is optional and adapters are not required to implement this feature for any entrypoint."
+  - "The application can disable log messages at runtime by setting the environment variable `UR_DISABLE_LOGS`."
+class: $x
+name: AdapterSetLoggingCallback
+decl: static
+params:
+  - type: $x_adapter_handle_t*
+    name: "phAdapters"
+    desc: "[in][range(0, NumAdapters)] array of adapters where the callback will be set."
+  - type: "uint32_t"
+    name: NumAdapters
+    desc: "[in] number of adapters pointed to by phAdapters."
+  - type: $x_logger_callback_t
+    name: pfnLogger
+    desc: |
+          [in][optional] Function pointer to the callback function that will process the warning messages.
+          If set to nullptr, the callback function will be unset."
+  - type: void*
+    name: pUserData
+    desc: "[in][out][optional] pointer to data to be passed to the callback."
+--- #--------------------------------------------------------------------------
 type: enum
 desc: "Identifies backend of the adapter"
 class: $x

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -270,8 +270,7 @@ etors:
     - name: ERROR_OBJECT_ALLOCATION_FAILURE
       desc: "Objection allocation failure"
     - name: ERROR_ADAPTER_SPECIFIC
-      desc: "An adapter specific warning/error has been reported and can be retrieved
-             via the urPlatformGetLastError entry point."
+      desc: "An adapter specific error has been reported and can be retrieved via the urAdapterGetLastError entry point."
     - name: ERROR_LAYER_NOT_PRESENT
       desc: "A requested layer was not found by the loader."
     - name: ERROR_UNKNOWN

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -278,6 +278,23 @@ etors:
       value: "0x7ffffffe"
       desc: "Unknown or internal error"
 --- #--------------------------------------------------------------------------
+type: enum
+desc: "Describes the type of a Unified Runtime log message."
+name: $x_log_level_t
+etors:
+  - name: DEBUG
+    desc: "A debug message. Typically contains information that is mostly useful to help debugging unified runtime behaviour."
+  - name: INFO
+    desc: "An info message. Contains information about successful operations."
+  - name: WARN
+    desc: |
+      A warning message. These messages might contain information about situations where unified 
+      runtime might not have behaved as expected."
+  - name: ERR
+    desc: |
+      An error message. Unified runtime has encountered an error that prevented it from performing a certain operation. 
+      In the case of adapter errors, it will also return an error code as the return value from the entrypoint."
+--- #--------------------------------------------------------------------------
 type: struct
 desc: "Base for all properties types"
 name: $x_base_properties_t

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -577,6 +577,9 @@ etors:
 - name: DEVICE_GET_SELECTED
   desc: Enumerator for $xDeviceGetSelected
   value: '220'
+- name: ADAPTER_SET_LOGGING_CALLBACK
+  desc: Enumerator for $xAdapterSetLoggingCallback
+  value: '221'
 ---
 type: enum
 desc: Defines structure types

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -139,7 +139,7 @@ namespace ur_loader
 
                 auto ${th.make_pfn_name(n, tags, obj)} = dditable->${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)};
 
-                ${th.make_pfn_name(n, tags, obj)}(&${obj['params'][0]['name']}[adapter_index], 1, ${obj['params'][2]['name']}, ${obj['params'][3]['name']});
+                ${th.make_pfn_name(n, tags, obj)}(&${obj['params'][0]['name']}[adapter_index], 1, ${obj['params'][2]['name']}, ${obj['params'][3]['name']}, ${obj['params'][4]['name']});
             }
 
         %else:

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -127,6 +127,21 @@ namespace ur_loader
         if( ${X}_RESULT_SUCCESS == result && ${obj['params'][4]['name']} != nullptr )
             *${obj['params'][4]['name']} = total_platform_handle_count;
 
+        %elif re.match(r"\w+AdapterSetLoggingCallback$", th.make_func_name(n, tags, obj)):
+            if (${obj['params'][0]['name']} == nullptr) {
+                return result;
+            }
+
+            for( uint32_t adapter_index = 0; adapter_index < ${obj['params'][1]['name']}; adapter_index++)
+            {
+                auto dditable =
+                reinterpret_cast<${n}_adapter_object_t *>( ${obj['params'][0]['name']}[adapter_index])->dditable;
+
+                auto ${th.make_pfn_name(n, tags, obj)} = dditable->${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)};
+
+                ${th.make_pfn_name(n, tags, obj)}(&${obj['params'][0]['name']}[adapter_index], 1, ${obj['params'][2]['name']}, ${obj['params'][3]['name']});
+            }
+
         %else:
         <%param_replacements={}%>
         %for i, item in enumerate(th.get_loader_prologue(n, tags, obj, meta)):

--- a/source/adapters/cuda/adapter.cpp
+++ b/source/adapters/cuda/adapter.cpp
@@ -111,9 +111,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
-                            ur_logger_callback_t pfnLogger, void *pUserData) {
-  adapter.logger.setLoggingCallback(&adapter, pfnLogger, pUserData);
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *, uint32_t, ur_log_level_t levelThreshold,
+    ur_logger_callback_t pfnLogger, void *pUserData) {
+  std::lock_guard<std::mutex> Guard(adapter.Mutex);
+  adapter.logger.setLoggingCallback(&adapter, levelThreshold, pfnLogger,
+                                    pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/adapter.cpp
+++ b/source/adapters/cuda/adapter.cpp
@@ -29,7 +29,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_log_level_t level,
                      const std::string &msg) override {
     std::cerr << msg << std::endl;
   }
@@ -108,5 +108,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
 
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
+                            ur_logger_callback_t pfnLogger, void *pUserData) {
+  adapter.logger.setLoggingCallback(&adapter, pfnLogger, pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -207,6 +207,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterRetain = urAdapterRetain;
   pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
   pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnAdapterSetLoggingCallback = urAdapterSetLoggingCallback;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/hip/adapter.cpp
+++ b/source/adapters/hip/adapter.cpp
@@ -18,6 +18,7 @@
 struct ur_adapter_handle_t_ {
   std::atomic<uint32_t> RefCount = 0;
   logger::Logger &logger;
+  std::mutex Mutex;
   ur_adapter_handle_t_();
 };
 
@@ -100,9 +101,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
-                            ur_logger_callback_t pfnLogger, void *pUserData) {
-  adapter.logger.setLoggingCallback(&adapter, pfnLogger, pUserData);
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *, uint32_t, ur_log_level_t levelThreshold,
+    ur_logger_callback_t pfnLogger, void *pUserData) {
+  std::lock_guard<std::mutex> Guard(adapter.Mutex);
+  adapter.logger.setLoggingCallback(&adapter, levelThreshold, pfnLogger,
+                                    pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/hip/adapter.cpp
+++ b/source/adapters/hip/adapter.cpp
@@ -99,3 +99,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
+                            ur_logger_callback_t pfnLogger, void *pUserData) {
+  adapter.logger.setLoggingCallback(&adapter, pfnLogger, pUserData);
+  return UR_RESULT_SUCCESS;
+}

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -207,6 +207,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
   pDdiTable->pfnAdapterRelease = urAdapterRelease;
   pDdiTable->pfnAdapterRetain = urAdapterRetain;
+  pDdiTable->pfnAdapterSetLoggingCallback = urAdapterSetLoggingCallback;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/adapter.cpp
+++ b/source/adapters/level_zero/adapter.cpp
@@ -297,9 +297,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
-                            ur_logger_callback_t pfnLogger, void *pUserData) {
-  Adapter.logger.setLoggingCallback(&Adapter, pfnLogger, pUserData);
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *, uint32_t, ur_log_level_t levelThreshold,
+    ur_logger_callback_t pfnLogger, void *pUserData) {
+  std::lock_guard<std::mutex> Guard(Adapter.Mutex);
+  Adapter.logger.setLoggingCallback(&Adapter, levelThreshold, pfnLogger,
+                                    pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/adapter.cpp
+++ b/source/adapters/level_zero/adapter.cpp
@@ -18,7 +18,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_log_level_t level,
                      const std::string &msg) override {
     fprintf(stderr, "%s", msg.c_str());
   }
@@ -294,5 +294,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
 
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
+                            ur_logger_callback_t pfnLogger, void *pUserData) {
+  Adapter.logger.setLoggingCallback(&Adapter, pfnLogger, pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -44,6 +44,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterRetain = urAdapterRetain;
   pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
   pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnAdapterSetLoggingCallback = urAdapterSetLoggingCallback;
 
   return retVal;
 }

--- a/source/adapters/native_cpu/adapter.cpp
+++ b/source/adapters/native_cpu/adapter.cpp
@@ -14,6 +14,7 @@
 struct ur_adapter_handle_t_ {
   std::atomic<uint32_t> RefCount = 0;
   logger::Logger &logger = logger::get_logger("native_cpu");
+  std::mutex Mutex;
 } Adapter;
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
@@ -64,9 +65,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
-                            ur_logger_callback_t pfnLogger, void *pUserData) {
-  Adapter.logger.setLoggingCallback(&Adapter, pfnLogger, pUserData);
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *, uint32_t, ur_log_level_t levelThreshold,
+    ur_logger_callback_t pfnLogger, void *pUserData) {
+  std::lock_guard<std::mutex> Guard(Adapter.Mutex);
+  Adapter.logger.setLoggingCallback(&Adapter, levelThreshold, pfnLogger,
+                                    pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/adapter.cpp
+++ b/source/adapters/native_cpu/adapter.cpp
@@ -63,3 +63,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
+                            ur_logger_callback_t pfnLogger, void *pUserData) {
+  Adapter.logger.setLoggingCallback(&Adapter, pfnLogger, pUserData);
+  return UR_RESULT_SUCCESS;
+}

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -204,6 +204,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
   pDdiTable->pfnAdapterRelease = urAdapterRelease;
   pDdiTable->pfnAdapterRetain = urAdapterRetain;
+  pDdiTable->pfnAdapterSetLoggingCallback = urAdapterSetLoggingCallback;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -151,10 +151,14 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                     ///< be set.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t
+        levelThreshold, ///< [in] The minimum log level that will activate pfnLogger.
+    ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+    ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t
         pfnLogger, ///< [in][optional] Function pointer to the callback function that will
                    ///< process the warning messages.
-                   ///< If set to nullptr, the callback function will be unset."
+                   ///< If set to nullptr, the callback function will be unset.
     void *
         pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
     ) try {
@@ -164,8 +168,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
     auto pfnAdapterSetLoggingCallback =
         d_context.urDdiTable.Global.pfnAdapterSetLoggingCallback;
     if (nullptr != pfnAdapterSetLoggingCallback) {
-        result = pfnAdapterSetLoggingCallback(phAdapters, NumAdapters,
-                                              pfnLogger, pUserData);
+        result = pfnAdapterSetLoggingCallback(
+            phAdapters, NumAdapters, levelThreshold, pfnLogger, pUserData);
     } else {
         // generic implementation
     }

--- a/source/adapters/opencl/adapter.cpp
+++ b/source/adapters/opencl/adapter.cpp
@@ -77,3 +77,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
+                            ur_logger_callback_t pfnLogger, void *pUserData) {
+  adapter.log.setLoggingCallback(&adapter, pfnLogger, pUserData);
+  return UR_RESULT_SUCCESS;
+}

--- a/source/adapters/opencl/adapter.cpp
+++ b/source/adapters/opencl/adapter.cpp
@@ -78,9 +78,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urAdapterSetLoggingCallback(ur_adapter_handle_t *, uint32_t,
-                            ur_logger_callback_t pfnLogger, void *pUserData) {
-  adapter.log.setLoggingCallback(&adapter, pfnLogger, pUserData);
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *, uint32_t, ur_log_level_t levelThreshold,
+    ur_logger_callback_t pfnLogger, void *pUserData) {
+  std::lock_guard<std::mutex> Guard(adapter.Mutex);
+  adapter.log.setLoggingCallback(&adapter, levelThreshold, pfnLogger,
+                                 pUserData);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -206,6 +206,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterRetain = urAdapterRetain;
   pDdiTable->pfnAdapterGetLastError = urAdapterGetLastError;
   pDdiTable->pfnAdapterGetInfo = urAdapterGetInfo;
+  pDdiTable->pfnAdapterSetLoggingCallback = urAdapterSetLoggingCallback;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/common/logger/ur_level.hpp
+++ b/source/common/logger/ur_level.hpp
@@ -11,8 +11,6 @@
 
 namespace logger {
 
-//enum class Level { DEBUG, INFO, WARN, ERR, QUIET };
-
 inline constexpr auto level_to_str(ur_log_level_t level) {
     switch (level) {
     case ur_log_level_t::UR_LOG_LEVEL_DEBUG:

--- a/source/common/logger/ur_level.hpp
+++ b/source/common/logger/ur_level.hpp
@@ -11,17 +11,17 @@
 
 namespace logger {
 
-enum class Level { DEBUG, INFO, WARN, ERR, QUIET };
+//enum class Level { DEBUG, INFO, WARN, ERR, QUIET };
 
-inline constexpr auto level_to_str(Level level) {
+inline constexpr auto level_to_str(ur_log_level_t level) {
     switch (level) {
-    case Level::DEBUG:
+    case ur_log_level_t::UR_LOG_LEVEL_DEBUG:
         return "DEBUG";
-    case Level::INFO:
+    case ur_log_level_t::UR_LOG_LEVEL_INFO:
         return "INFO";
-    case Level::WARN:
+    case ur_log_level_t::UR_LOG_LEVEL_WARN:
         return "WARNING";
-    case Level::ERR:
+    case ur_log_level_t::UR_LOG_LEVEL_ERR:
         return "ERROR";
     default:
         return "";
@@ -31,13 +31,14 @@ inline constexpr auto level_to_str(Level level) {
 inline auto str_to_level(std::string name) {
     struct lvl_name {
         std::string name;
-        Level lvl;
+        ur_log_level_t lvl;
     };
 
-    const lvl_name lvl_names[] = {{"debug", Level::DEBUG},
-                                  {"info", Level::INFO},
-                                  {"warning", Level::WARN},
-                                  {"error", Level::ERR}};
+    const lvl_name lvl_names[] = {
+        {"debug", ur_log_level_t::UR_LOG_LEVEL_DEBUG},
+        {"info", ur_log_level_t::UR_LOG_LEVEL_INFO},
+        {"warning", ur_log_level_t::UR_LOG_LEVEL_WARN},
+        {"error", ur_log_level_t::UR_LOG_LEVEL_ERR}};
 
     for (auto const &item : lvl_names) {
         if (item.name.compare(name) == 0) {

--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -25,22 +25,26 @@ inline void init(std::string name) { get_logger(std::move(name)); }
 
 template <typename... Args>
 inline void debug(const char *format, Args &&...args) {
-    get_logger().log(logger::Level::DEBUG, format, std::forward<Args>(args)...);
+    get_logger().log(ur_log_level_t::UR_LOG_LEVEL_DEBUG, format,
+                     std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(const char *format, Args &&...args) {
-    get_logger().log(logger::Level::INFO, format, std::forward<Args>(args)...);
+    get_logger().log(ur_log_level_t::UR_LOG_LEVEL_INFO, format,
+                     std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warning(const char *format, Args &&...args) {
-    get_logger().log(logger::Level::WARN, format, std::forward<Args>(args)...);
+    get_logger().log(ur_log_level_t::UR_LOG_LEVEL_WARN, format,
+                     std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(const char *format, Args &&...args) {
-    get_logger().log(logger::Level::ERR, format, std::forward<Args>(args)...);
+    get_logger().log(ur_log_level_t::UR_LOG_LEVEL_ERR, format,
+                     std::forward<Args>(args)...);
 }
 
 template <typename... Args>
@@ -51,32 +55,32 @@ inline void always(const char *format, Args &&...args) {
 template <typename... Args>
 inline void debug(const logger::LegacyMessage &p, const char *format,
                   Args &&...args) {
-    get_logger().log(p, logger::Level::DEBUG, format,
+    get_logger().log(p, ur_log_level_t::UR_LOG_LEVEL_DEBUG, format,
                      std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(logger::LegacyMessage p, const char *format, Args &&...args) {
-    get_logger().log(p, logger::Level::INFO, format,
+    get_logger().log(p, ur_log_level_t::UR_LOG_LEVEL_INFO, format,
                      std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warning(logger::LegacyMessage p, const char *format,
                     Args &&...args) {
-    get_logger().log(p, logger::Level::WARN, format,
+    get_logger().log(p, ur_log_level_t::UR_LOG_LEVEL_WARN, format,
                      std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(logger::LegacyMessage p, const char *format, Args &&...args) {
-    get_logger().log(p, logger::Level::ERR, format,
+    get_logger().log(p, ur_log_level_t::UR_LOG_LEVEL_ERR, format,
                      std::forward<Args>(args)...);
 }
 
-inline void setLevel(logger::Level level) { get_logger().setLevel(level); }
+inline void setLevel(ur_log_level_t level) { get_logger().setLevel(level); }
 
-inline void setFlushLevel(logger::Level level) {
+inline void setFlushLevel(ur_log_level_t level) {
     get_logger().setFlushLevel(level);
 }
 
@@ -109,11 +113,9 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix) {
     std::transform(logger_name.begin(), logger_name.end(), logger_name.begin(),
                    ::toupper);
     std::stringstream env_var_name;
-    const auto default_level = logger::Level::QUIET;
-    const auto default_flush_level = logger::Level::ERR;
     const std::string default_output = "stderr";
-    auto level = default_level;
-    auto flush_level = default_flush_level;
+    auto level = ur_log_level_t::UR_LOG_LEVEL_ERR;
+    auto flush_level = ur_log_level_t::UR_LOG_LEVEL_ERR;
     std::unique_ptr<logger::Sink> sink;
 
     env_var_name << "UR_LOG_" << logger_name;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -167,10 +167,14 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                     ///< be set.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t
+        levelThreshold, ///< [in] The minimum log level that will activate pfnLogger.
+    ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+    ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t
         pfnLogger, ///< [in][optional] Function pointer to the callback function that will
                    ///< process the warning messages.
-                   ///< If set to nullptr, the callback function will be unset."
+                   ///< If set to nullptr, the callback function will be unset.
     void *
         pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
 ) {
@@ -182,13 +186,13 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
     }
 
     ur_adapter_set_logging_callback_params_t params = {
-        &phAdapters, &NumAdapters, &pfnLogger, &pUserData};
+        &phAdapters, &NumAdapters, &levelThreshold, &pfnLogger, &pUserData};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_ADAPTER_SET_LOGGING_CALLBACK,
                              "urAdapterSetLoggingCallback", &params);
 
-    ur_result_t result = pfnAdapterSetLoggingCallback(phAdapters, NumAdapters,
-                                                      pfnLogger, pUserData);
+    ur_result_t result = pfnAdapterSetLoggingCallback(
+        phAdapters, NumAdapters, levelThreshold, pfnLogger, pUserData);
 
     context.notify_end(UR_FUNCTION_ADAPTER_SET_LOGGING_CALLBACK,
                        "urAdapterSetLoggingCallback", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -205,10 +205,14 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                     ///< be set.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t
+        levelThreshold, ///< [in] The minimum log level that will activate pfnLogger.
+    ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+    ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t
         pfnLogger, ///< [in][optional] Function pointer to the callback function that will
                    ///< process the warning messages.
-                   ///< If set to nullptr, the callback function will be unset."
+                   ///< If set to nullptr, the callback function will be unset.
     void *
         pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
 ) {
@@ -223,10 +227,14 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         if (NULL == phAdapters) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (UR_LOG_LEVEL_ERR < levelThreshold) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
     }
 
-    ur_result_t result = pfnAdapterSetLoggingCallback(phAdapters, NumAdapters,
-                                                      pfnLogger, pUserData);
+    ur_result_t result = pfnAdapterSetLoggingCallback(
+        phAdapters, NumAdapters, levelThreshold, pfnLogger, pUserData);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -195,10 +195,14 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                     ///< be set.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t
+        levelThreshold, ///< [in] The minimum log level that will activate pfnLogger.
+    ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+    ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t
         pfnLogger, ///< [in][optional] Function pointer to the callback function that will
                    ///< process the warning messages.
-                   ///< If set to nullptr, the callback function will be unset."
+                   ///< If set to nullptr, the callback function will be unset.
     void *
         pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
 ) {
@@ -217,8 +221,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         auto pfnAdapterSetLoggingCallback =
             dditable->ur.Global.pfnAdapterSetLoggingCallback;
 
-        pfnAdapterSetLoggingCallback(&phAdapters[adapter_index], 1, pfnLogger,
-                                     pUserData);
+        pfnAdapterSetLoggingCallback(&phAdapters[adapter_index], 1,
+                                     levelThreshold, pfnLogger, pUserData);
     }
 
     return result;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -467,6 +467,50 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a function callback for use by the adapters when logging messages.
+///
+/// @details
+///     - Sets a function callback that will be used by the adapters when
+///       logging messages.
+///     - The callback will be called for every message logged by the adapters
+///       specified in `phAdapters`.
+///     - Sending log messages is optional and adapters are not required to
+///       implement this feature for any entrypoint.
+///     - The application can disable log messages at runtime by setting the
+///       environment variable `UR_DISABLE_LOGS`.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phAdapters`
+ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *
+        phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
+                    ///< be set.
+    uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_logger_callback_t
+        pfnLogger, ///< [in][optional] Function pointer to the callback function that will
+                   ///< process the warning messages.
+                   ///< If set to nullptr, the callback function will be unset."
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
+    ) try {
+    auto pfnAdapterSetLoggingCallback =
+        ur_lib::context->urDdiTable.Global.pfnAdapterSetLoggingCallback;
+    if (nullptr == pfnAdapterSetLoggingCallback) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnAdapterSetLoggingCallback(phAdapters, NumAdapters, pfnLogger,
+                                        pUserData);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -364,7 +364,7 @@ ur_result_t UR_APICALL urAdapterRetain(
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///
-/// * The message and error code storage is will only be valid if a previously
+/// * The message and error code storage will only be valid if a previously
 ///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///
 /// * The memory pointed to by the C string returned in `ppMessage` is owned by
@@ -395,6 +395,8 @@ ur_result_t UR_APICALL urAdapterRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
 ///         + `NULL == pError`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
     const char **
@@ -476,8 +478,6 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///       specified in `phAdapters`.
 ///     - Sending log messages is optional and adapters are not required to
 ///       implement this feature for any entrypoint.
-///     - The application can disable log messages at runtime by setting the
-///       environment variable `UR_DISABLE_LOGS`.
 ///     - Calling this function again with the same adapter handle will replace
 ///       the previous values.
 ///     - To unset the callback, use `nullptr` as the value for `pfnLogger`.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -478,6 +478,11 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///       implement this feature for any entrypoint.
 ///     - The application can disable log messages at runtime by setting the
 ///       environment variable `UR_DISABLE_LOGS`.
+///     - Calling this function again with the same adapter handle will replace
+///       the previous values.
+///     - To unset the callback, use `nullptr` as the value for `pfnLogger`.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be thread-safe.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -486,15 +491,21 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phAdapters`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOG_LEVEL_ERR < levelThreshold`
 ur_result_t UR_APICALL urAdapterSetLoggingCallback(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                     ///< be set.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t
+        levelThreshold, ///< [in] The minimum log level that will activate pfnLogger.
+    ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+    ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t
         pfnLogger, ///< [in][optional] Function pointer to the callback function that will
                    ///< process the warning messages.
-                   ///< If set to nullptr, the callback function will be unset."
+                   ///< If set to nullptr, the callback function will be unset.
     void *
         pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
     ) try {
@@ -504,8 +515,8 @@ ur_result_t UR_APICALL urAdapterSetLoggingCallback(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnAdapterSetLoggingCallback(phAdapters, NumAdapters, pfnLogger,
-                                        pUserData);
+    return pfnAdapterSetLoggingCallback(phAdapters, NumAdapters, levelThreshold,
+                                        pfnLogger, pUserData);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -59,6 +59,13 @@ ur_result_t urPrintResult(enum ur_result_t value, char *buffer,
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintLogLevel(enum ur_log_level_t value, char *buffer,
+                            const size_t buff_size, size_t *out_size) {
+    std::stringstream ss;
+    ss << value;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t urPrintBaseProperties(const struct ur_base_properties_t params,
                                   char *buffer, const size_t buff_size,
                                   size_t *out_size) {
@@ -1049,6 +1056,14 @@ ur_result_t
 urPrintAdapterGetInfoParams(const struct ur_adapter_get_info_params_t *params,
                             char *buffer, const size_t buff_size,
                             size_t *out_size) {
+    std::stringstream ss;
+    ss << params;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t urPrintAdapterSetLoggingCallbackParams(
+    const struct ur_adapter_set_logging_callback_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size) {
     std::stringstream ss;
     ss << params;
     return str_copy(&ss, buffer, buff_size, out_size);

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -421,6 +421,11 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///       implement this feature for any entrypoint.
 ///     - The application can disable log messages at runtime by setting the
 ///       environment variable `UR_DISABLE_LOGS`.
+///     - Calling this function again with the same adapter handle will replace
+///       the previous values.
+///     - To unset the callback, use `nullptr` as the value for `pfnLogger`.
+///     - The application may call this function from simultaneous threads.
+///     - The implementation of this function should be thread-safe.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -429,15 +434,21 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phAdapters`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOG_LEVEL_ERR < levelThreshold`
 ur_result_t UR_APICALL urAdapterSetLoggingCallback(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
                     ///< be set.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_log_level_t
+        levelThreshold, ///< [in] The minimum log level that will activate pfnLogger.
+    ///< For example, if logLevel is ::UR_LOG_LEVEL_INFO, all messages except
+    ///< for ::UR_LOG_LEVEL_DEBUG will trigger a call to the callback.
     ur_logger_callback_t
         pfnLogger, ///< [in][optional] Function pointer to the callback function that will
                    ///< process the warning messages.
-                   ///< If set to nullptr, the callback function will be unset."
+                   ///< If set to nullptr, the callback function will be unset.
     void *
         pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
 ) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -322,7 +322,7 @@ ur_result_t UR_APICALL urAdapterRetain(
 /// * Implementations *must* store the message and error code in thread-local
 ///   storage prior to returning ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///
-/// * The message and error code storage is will only be valid if a previously
+/// * The message and error code storage will only be valid if a previously
 ///   called entry-point returned ::UR_RESULT_ERROR_ADAPTER_SPECIFIC.
 ///
 /// * The memory pointed to by the C string returned in `ppMessage` is owned by
@@ -353,6 +353,8 @@ ur_result_t UR_APICALL urAdapterRetain(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == ppMessage`
 ///         + `NULL == pError`
+///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
     const char **
@@ -419,8 +421,6 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///       specified in `phAdapters`.
 ///     - Sending log messages is optional and adapters are not required to
 ///       implement this feature for any entrypoint.
-///     - The application can disable log messages at runtime by setting the
-///       environment variable `UR_DISABLE_LOGS`.
 ///     - Calling this function again with the same adapter handle will replace
 ///       the previous values.
 ///     - To unset the callback, use `nullptr` as the value for `pfnLogger`.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -410,6 +410,42 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a function callback for use by the adapters when logging messages.
+///
+/// @details
+///     - Sets a function callback that will be used by the adapters when
+///       logging messages.
+///     - The callback will be called for every message logged by the adapters
+///       specified in `phAdapters`.
+///     - Sending log messages is optional and adapters are not required to
+///       implement this feature for any entrypoint.
+///     - The application can disable log messages at runtime by setting the
+///       environment variable `UR_DISABLE_LOGS`.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phAdapters`
+ur_result_t UR_APICALL urAdapterSetLoggingCallback(
+    ur_adapter_handle_t *
+        phAdapters, ///< [in][range(0, NumAdapters)] array of adapters where the callback will
+                    ///< be set.
+    uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters.
+    ur_logger_callback_t
+        pfnLogger, ///< [in][optional] Function pointer to the callback function that will
+                   ///< process the warning messages.
+                   ///< If set to nullptr, the callback function will be unset."
+    void *
+        pUserData ///< [in][out][optional] pointer to data to be passed to the callback.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details

--- a/test/conformance/adapter/CMakeLists.txt
+++ b/test/conformance/adapter/CMakeLists.txt
@@ -8,4 +8,5 @@ add_conformance_test(adapter
     urAdapterGetInfo.cpp
     urAdapterGetLastError.cpp
     urAdapterRetain.cpp
-    urAdapterRelease.cpp)
+    urAdapterRelease.cpp
+    urAdapterSetLoggingCallback.cpp)

--- a/test/conformance/adapter/urAdapterSetLoggingCallback.cpp
+++ b/test/conformance/adapter/urAdapterSetLoggingCallback.cpp
@@ -19,8 +19,8 @@ void loggerCallback(ur_adapter_handle_t, const char *, ur_log_level_t,
 }
 
 TEST_F(urAdapterSetLoggingCallbackTest, Success) {
-    ASSERT_SUCCESS(urAdapterSetLoggingCallback(adapters.data(), 1,
-                                               loggerCallback, nullptr));
+    ASSERT_SUCCESS(urAdapterSetLoggingCallback(
+        adapters.data(), 1, UR_LOG_LEVEL_DEBUG, loggerCallback, nullptr));
     ASSERT_FALSE(callbackError);
 }
 
@@ -30,13 +30,22 @@ TEST_F(urAdapterSetLoggingCallbackTest, Success) {
 TEST_F(urAdapterSetLoggingCallbackTest, SuccessUserData) {
 
     void *callbackUserData = reinterpret_cast<void *>(&data);
-    ASSERT_SUCCESS(urAdapterSetLoggingCallback(
-        adapters.data(), 1, loggerCallback, callbackUserData));
+    ASSERT_SUCCESS(
+        urAdapterSetLoggingCallback(adapters.data(), 1, UR_LOG_LEVEL_DEBUG,
+                                    loggerCallback, callbackUserData));
     ASSERT_FALSE(callbackError);
 }
 
 TEST_F(urAdapterSetLoggingCallbackTest, NullCallback) {
-    ASSERT_SUCCESS(
-        urAdapterSetLoggingCallback(adapters.data(), 1, nullptr, nullptr));
+    ASSERT_SUCCESS(urAdapterSetLoggingCallback(
+        adapters.data(), 1, UR_LOG_LEVEL_DEBUG, nullptr, nullptr));
+    ASSERT_FALSE(callbackError);
+}
+
+TEST_F(urAdapterSetLoggingCallbackTest, InvalidLevelThreshold) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
+                     urAdapterSetLoggingCallback(adapters.data(), 1,
+                                                 UR_LOG_LEVEL_FORCE_UINT32,
+                                                 nullptr, nullptr));
     ASSERT_FALSE(callbackError);
 }

--- a/test/conformance/adapter/urAdapterSetLoggingCallback.cpp
+++ b/test/conformance/adapter/urAdapterSetLoggingCallback.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.h"
+
+using urAdapterSetLoggingCallbackTest = uur::runtime::urAdapterTest;
+
+int data = 42;
+bool callbackError = false;
+void loggerCallback(ur_adapter_handle_t, const char *, ur_log_level_t,
+                    void *pUserData) {
+    if (pUserData) {
+        if (*reinterpret_cast<int *>(pUserData) != 42) {
+            callbackError = true;
+        }
+    }
+}
+
+TEST_F(urAdapterSetLoggingCallbackTest, Success) {
+    ASSERT_SUCCESS(urAdapterSetLoggingCallback(adapters.data(), 1,
+                                               loggerCallback, nullptr));
+    ASSERT_FALSE(callbackError);
+}
+
+/* Tries to check if the user data is passed correctly to the UR logger.
+ * Unfortunately, there is no way to make sure that the adapters will call the
+ * logger. So this will just pass if there are no calls to the logger. */
+TEST_F(urAdapterSetLoggingCallbackTest, SuccessUserData) {
+
+    void *callbackUserData = reinterpret_cast<void *>(&data);
+    ASSERT_SUCCESS(urAdapterSetLoggingCallback(
+        adapters.data(), 1, loggerCallback, callbackUserData));
+    ASSERT_FALSE(callbackError);
+}
+
+TEST_F(urAdapterSetLoggingCallbackTest, NullCallback) {
+    ASSERT_SUCCESS(
+        urAdapterSetLoggingCallback(adapters.data(), 1, nullptr, nullptr));
+    ASSERT_FALSE(callbackError);
+}

--- a/test/loader/CMakeLists.txt
+++ b/test/loader/CMakeLists.txt
@@ -8,6 +8,7 @@ set_tests_properties(example-hello-world PROPERTIES LABELS "loader"
     ENVIRONMENT "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_null>\""
 )
 
+add_subdirectory(adapter)
 add_subdirectory(adapter_registry)
 add_subdirectory(loader_config)
 add_subdirectory(loader_lifetime)

--- a/test/loader/adapter/CMakeLists.txt
+++ b/test/loader/adapter/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (C) 2024 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_ur_executable(test-loader-adapter
+    urAdapterSetLoggingCallback.cpp
+)
+
+target_link_libraries(test-loader-adapter
+    PRIVATE
+    ${PROJECT_NAME}::common
+    ${PROJECT_NAME}::headers
+    ${PROJECT_NAME}::loader
+    gmock
+    GTest::gtest_main
+)
+
+add_test(NAME loader-adapter
+    COMMAND test-loader-adapter
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/test/loader/adapter/urAdapterSetLoggingCallback.cpp
+++ b/test/loader/adapter/urAdapterSetLoggingCallback.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "ur_api.h"
+#include <gtest/gtest.h>
+
+#ifndef ASSERT_SUCCESS
+#define ASSERT_SUCCESS(ACTUAL) ASSERT_EQ(UR_RESULT_SUCCESS, ACTUAL)
+#endif
+
+int data = 42;
+bool callbackError = false;
+void loggerCallback(ur_adapter_handle_t, const char *, ur_log_level_t,
+                    void *pUserData) {
+    if (pUserData) {
+        if (*reinterpret_cast<int *>(pUserData) != 42) {
+            callbackError = true;
+        }
+    }
+}
+
+struct LoaderAdapterTest : ::testing::Test {
+    void SetUp() override {
+        ASSERT_SUCCESS(urLoaderInit(0, nullptr));
+        ASSERT_SUCCESS(urAdapterGet(0, nullptr, &adapterCount));
+        adapters.resize(adapterCount);
+        ASSERT_SUCCESS(urAdapterGet(adapterCount, adapters.data(), nullptr));
+    }
+
+    void TearDown() override { ASSERT_SUCCESS(urLoaderTearDown()); }
+
+    std::vector<ur_adapter_handle_t> adapters;
+    uint32_t adapterCount = 0;
+};
+
+using LoaderAdapterSetLoggingCallbackTest = LoaderAdapterTest;
+
+TEST_F(LoaderAdapterSetLoggingCallbackTest, Success) {
+    ASSERT_SUCCESS(urAdapterSetLoggingCallback(adapters.data(), adapterCount,
+                                               loggerCallback, &data));
+    urAdapterGet(adapterCount, adapters.data(), nullptr);
+    ASSERT_FALSE(callbackError);
+}

--- a/test/loader/adapter/urAdapterSetLoggingCallback.cpp
+++ b/test/loader/adapter/urAdapterSetLoggingCallback.cpp
@@ -39,6 +39,7 @@ using LoaderAdapterSetLoggingCallbackTest = LoaderAdapterTest;
 
 TEST_F(LoaderAdapterSetLoggingCallbackTest, Success) {
     ASSERT_SUCCESS(urAdapterSetLoggingCallback(adapters.data(), adapterCount,
+                                               UR_LOG_LEVEL_DEBUG,
                                                loggerCallback, &data));
     urAdapterGet(adapterCount, adapters.data(), nullptr);
     ASSERT_FALSE(callbackError);

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -91,7 +91,7 @@ class DefaultLoggerWithFileSink : public UniquePtrLoggerWithFilesink {
   protected:
     void SetUp() override {
         logger = std::make_unique<logger::Logger>(
-            logger::Level::WARN,
+            ur_log_level_t ::UR_LOG_LEVEL_WARN,
             std::make_unique<logger::FileSink>(logger_name, file_path));
     }
 };

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -60,7 +60,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
-    auto level = ur_log_level_t ::UR_LOG_LEVEL_DEBUG;
+    auto level = ur_log_level_t ::UR_LOG_LEVEL_INFO;
     logger->setLevel(level);
     logger->setFlushLevel(level);
     logger->info("Test message: {}", "success");

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -51,7 +51,7 @@ TEST_F(DefaultLoggerWithFileSink, NoBraces) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
-    auto level = logger::Level::DEBUG;
+    auto level = ur_log_level_t ::UR_LOG_LEVEL_DEBUG;
     logger->setLevel(level);
     logger->setFlushLevel(level);
     logger->debug("Test message: {}", "success");
@@ -60,7 +60,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
-    auto level = logger::Level::INFO;
+    auto level = ur_log_level_t ::UR_LOG_LEVEL_DEBUG;
     logger->setLevel(level);
     logger->setFlushLevel(level);
     logger->info("Test message: {}", "success");
@@ -70,7 +70,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelWarning) {
-    auto level = logger::Level::WARN;
+    auto level = ur_log_level_t ::UR_LOG_LEVEL_WARN;
     logger->setLevel(level);
     logger->warning("Test message: {}", "success");
     logger->info("This should not be printed: {}", 42);
@@ -79,7 +79,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelWarning) {
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelError) {
-    logger->setLevel(logger::Level::ERR);
+    logger->setLevel(ur_log_level_t ::UR_LOG_LEVEL_ERR);
     logger->error("Test message: {}", "success");
     logger->warning("This should not be printed: {}", 42);
 
@@ -88,7 +88,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelError) {
 
 //////////////////////////////////////////////////////////////////////////////
 TEST_F(UniquePtrLoggerWithFilesink, SetLogLevelAndFlushLevelDebugWithCtor) {
-    auto level = logger::Level::DEBUG;
+    auto level = ur_log_level_t ::UR_LOG_LEVEL_DEBUG;
     logger = std::make_unique<logger::Logger>(
         level,
         std::make_unique<logger::FileSink>(logger_name, file_path, level));
@@ -106,15 +106,17 @@ TEST_F(UniquePtrLoggerWithFilesink, NestedFilePath) {
     filesystem::create_directories(file_path);
     file_path /= file_name;
     logger = std::make_unique<logger::Logger>(
-        logger::Level::WARN, std::make_unique<logger::FileSink>(
-                                 logger_name, file_path, logger::Level::WARN));
+        ur_log_level_t ::UR_LOG_LEVEL_WARN,
+        std::make_unique<logger::FileSink>(logger_name, file_path,
+                                           ur_log_level_t ::UR_LOG_LEVEL_WARN));
 
     logger->warning("Test message: {}", "success");
     test_msg << test_msg_prefix << "[WARNING]: Test message: success\n";
 }
 
 TEST_F(UniquePtrLoggerWithFilesinkFail, NullSink) {
-    logger = std::make_unique<logger::Logger>(logger::Level::INFO, nullptr);
+    logger = std::make_unique<logger::Logger>(
+        ur_log_level_t ::UR_LOG_LEVEL_DEBUG, nullptr);
     logger->info("This should not be printed: {}", 42);
     test_msg.clear();
 }
@@ -128,7 +130,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(FileSinkLoggerMultipleThreads, Multithreaded) {
     std::vector<std::thread> threads;
     auto local_logger = logger::Logger(
-        logger::Level::WARN,
+        ur_log_level_t ::UR_LOG_LEVEL_WARN,
         std::make_unique<logger::FileSink>(logger_name, file_path, true));
     constexpr int message_count = 50;
 
@@ -175,7 +177,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(CommonLoggerWithMultipleThreads, StdoutMultithreaded) {
     std::vector<std::thread> threads;
     auto local_logger =
-        logger::Logger(logger::Level::WARN,
+        logger::Logger(ur_log_level_t ::UR_LOG_LEVEL_WARN,
                        std::make_unique<logger::StdoutSink>("test", true));
     constexpr int message_count = 50;
 


### PR DESCRIPTION
Temporarily creating the PR on top of a branch on my fork which contains the following unmerged PR (they are dependencies for this change): https://github.com/oneapi-src/unified-runtime/pull/1359, https://github.com/oneapi-src/unified-runtime/pull/1347, https://github.com/oneapi-src/unified-runtime/pull/1345, https://github.com/oneapi-src/unified-runtime/pull/1342, https://github.com/oneapi-src/unified-runtime/pull/1032

